### PR TITLE
Update script to be more useful, add BR setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push]
 
 jobs:
-  build-1:
+  build-withcmake:
     runs-on: ubuntu-16.04
 
     steps:
@@ -11,7 +11,7 @@ jobs:
     - name: Run the build
       run: ./RaspiFullInstall.sh
 
-  build-2:
+  build-aptcmake:
     runs-on: ubuntu-18.04
 
     steps:
@@ -19,6 +19,7 @@ jobs:
     - name: Run the build, getting cmake from apt
       run: |
         #On this build, use apt cmake to check that works
+        sudo rm /usr/local/bin/cmake*
         sudo apt purge --auto-remove cmake
         wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
         sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
         matrix:
             os: [ubuntu-16.04, ubuntu-18.04]
-            node: [6, 8, 10]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+        matrix:
+            os: [ubuntu-16.04, ubuntu-18.04]
+            node: [6, 8, 10]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run the build
+      run: ./RaspiFullInstall.sh
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,16 +3,26 @@ name: CI
 on: [push]
 
 jobs:
-  build:
-
-    runs-on: ${{ matrix.os }}
-    
-    strategy:
-        matrix:
-            os: [ubuntu-16.04, ubuntu-18.04]
+  build-1:
+    runs-on: ubuntu-16.04
 
     steps:
     - uses: actions/checkout@v1
     - name: Run the build
       run: ./RaspiFullInstall.sh
 
+  build-2:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run the build, getting cmake from apt
+      run: |
+        #On this build, use apt cmake to check that works
+        sudo apt purge --auto-remove cmake
+        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
+        sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+        sudo apt update
+        ./RaspiFullInstall.sh
+        # Check cmake was installed, this errors if cmake not installed.
+        dpkg -l cmake

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Install Scripts
+
+These scripts are helper scripts for setting up cascoda software on linux systems.
+
+## FullInstall
+
+This script installs the cascoda-sdk on a linux system that uses apt (such as debian/ubuntu) and builds it. It can be run using the ``RaspiFullInstall.sh`` script, or using one of the following one liners:
+
+``bash
+bash <(curl -Ls https://raw.githubusercontent.com/Cascoda/install-script/master/RaspiFullInstall.sh)
+``
+or
+``bash
+bash <(curl -Ls cascoda.com/scripts/fullinstall)
+``
+
+## BRSetup
+
+This script sets up a Raspberry Pi with Cascoda Pi Hat as an openthread border router. It can be run using the ``RaspiBRSetup.sh`` script, or using one of the following one liners:
+
+``bash
+bash <(curl -Ls https://raw.githubusercontent.com/Cascoda/install-script/master/RaspiBRSetup.sh)
+``
+or
+``bash
+bash <(curl -Ls cascoda.com/scripts/brsetup)
+``
+

--- a/README.md
+++ b/README.md
@@ -6,23 +6,23 @@ These scripts are helper scripts for setting up cascoda software on linux system
 
 This script installs the cascoda-sdk on a linux system that uses apt (such as debian/ubuntu) and builds it. It can be run using the ``RaspiFullInstall.sh`` script, or using one of the following one liners:
 
-``bash
+```bash
 bash <(curl -Ls https://raw.githubusercontent.com/Cascoda/install-script/master/RaspiFullInstall.sh)
-``
+```
 or
-``bash
+```bash
 bash <(curl -Ls cascoda.com/scripts/fullinstall)
-``
+```
 
 ## BRSetup
 
 This script sets up a Raspberry Pi with Cascoda Pi Hat as an openthread border router. It can be run using the ``RaspiBRSetup.sh`` script, or using one of the following one liners:
 
-``bash
+```bash
 bash <(curl -Ls https://raw.githubusercontent.com/Cascoda/install-script/master/RaspiBRSetup.sh)
-``
+```
 or
-``bash
+```bash
 bash <(curl -Ls cascoda.com/scripts/brsetup)
-``
+```
 

--- a/RaspiBRSetup.sh
+++ b/RaspiBRSetup.sh
@@ -5,13 +5,32 @@
 # Function to die with error
 die() { echo "Error: " "$*" 1>&2 ; exit 1; }
 
+INSTALL_BRANCH="master"
+
+# Get options passed to script, such as branch ids
+while getopts ":b:" opt; do
+	case ${opt} in
+	b )
+		INSTALL_BRANCH=${OPTARG}
+		;;
+	\? )
+		echo "Invalid option: ${opt} ${OPTARG}" 1>&2
+		echo "Usage: $0 [-b scriptbranch]" 1>&2
+		;;
+	: )
+		echo "Invalid option, -${OPTARG} requires argument" 1>&2
+		;;
+	esac
+done
+
 # First run the full install script (download it if not found)
 MYDIR=$(dirname "$0")
 FULLINSTALL_SCRIPT="${MYDIR}/RaspiFullInstall.sh"
 
 if [ ! -f "${FULLINSTALL_SCRIPT}" ]
 then
-	bash <(curl -Ls https://raw.githubusercontent.com/Cascoda/install-script/master/RaspiFullInstall.sh) || die "Downloading and installing cascoda-sdk"
+	echo "Target script branch is ${INSTALL_BRANCH}"
+	bash <(curl -Ls https://raw.githubusercontent.com/Cascoda/install-script/${INSTALL_BRANCH}/RaspiFullInstall.sh) || die "Downloading and installing cascoda-sdk"
 else
 	# run install script
 	${FULLINSTALL_SCRIPT} || die "Installing cascoda-sdk"

--- a/RaspiBRSetup.sh
+++ b/RaspiBRSetup.sh
@@ -11,11 +11,12 @@ FULLINSTALL_SCRIPT="${MYDIR}/RaspiFullInstall.sh"
 
 if [ ! -f "${FULLINSTALL_SCRIPT}" ]
 then
-	curl https://raw.githubusercontent.com/Cascoda/install-script/master/RaspiFullInstall.sh -o "${FULLINSTALL_SCRIPT}" || die "Downloading install script"
-fi	
+	bash <(curl -Ls https://raw.githubusercontent.com/Cascoda/install-script/master/RaspiFullInstall.sh) || die "Downloading and installing cascoda-sdk"
+else
+	# run install script
+	${FULLINSTALL_SCRIPT} || die "Installing cascoda-sdk"
+fi
 
-# run install script
-${FULLINSTALL_SCRIPT} || die "Installing cascoda-sdk"
 
 # get build dir
 MACHINE_NAME="$(uname -m)"
@@ -34,7 +35,7 @@ echo "Cascoda NCPAPP installed to ${NCPAPP_PATH}."
 # Pull if already exists, otherwise clone.
 if [ -d ot-br-posix/.git ]
 then
-        git pull -C ot-br-posix || die "Failed to pull ot-br-posix"
+        git -C ot-br-posix pull || die "Failed to pull ot-br-posix"
 else
         git clone https://github.com/openthread/ot-br-posix ot-br-posix || die "Failed to clone ot-br-posix"
 fi

--- a/RaspiBRSetup.sh
+++ b/RaspiBRSetup.sh
@@ -63,6 +63,11 @@ cd ot-br-posix
 ./script/bootstrap || die "Bootstrapping ot-br-posix"
 ./script/setup || die "ot-br-posix setup"
 
+# Disable raspberry pi console on UART, enable uart, add required environment variable to use pi hat
+sudo sed -i 's/console=serial0,115200 //g' /boot/cmdline.txt
+echo "enable_uart=1" | sudo tee -a /boot/config.txt
+echo "CASCODA_UART=/dev/serial0,1000000" | sudo tee -a /etc/default/wpantund
+
 # configure our ncpapp as the socket
 WPANTUND_CONF="/etc/wpantund.conf"
 if grep -Eq '^Config:NCP:SocketPath.*' ${WPANTUND_CONF}

--- a/RaspiBRSetup.sh
+++ b/RaspiBRSetup.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# A script to setup a fresh Raspberry Pi as Thread Border Router
+
+# Function to die with error
+die() { echo "Error: " "$*" 1>&2 ; exit 1; }
+
+# First run the full install script (download it if not found)
+MYDIR=$(dirname "$0")
+FULLINSTALL_SCRIPT="${MYDIR}/RaspiFullInstall.sh"
+
+if [ ! -f "${FULLINSTALL_SCRIPT}" ]
+then
+	curl https://raw.githubusercontent.com/Cascoda/install-script/master/RaspiFullInstall.sh -o "${FULLINSTALL_SCRIPT}" || die "Downloading install script"
+fi	
+
+# run install script
+${FULLINSTALL_SCRIPT} || die "Installing cascoda-sdk"
+
+# get build dir
+MACHINE_NAME="$(uname -m)"
+BUILDDIR="build-${MACHINE_NAME}"
+
+# make an install directory for the ncpapp, copy it over
+CASCODA_OPT="/opt/cascoda"
+NCPAPP_PATH="${CASCODA_OPT}/ncpapp"
+sudo mkdir -p ${CASCODA_OPT} || die "Making install dir"
+sudo cp "${BUILDDIR}/bin/ncpapp" "$NCPAPP_PATH"
+
+echo "Cascoda NCPAPP installed to ${NCPAPP_PATH}."
+
+# Install OpenThread Border Router software
+
+# Pull if already exists, otherwise clone.
+if [ -d ot-br-posix/.git ]
+then
+        git pull -C ot-br-posix || die "Failed to pull ot-br-posix"
+else
+        git clone https://github.com/openthread/ot-br-posix ot-br-posix || die "Failed to clone ot-br-posix"
+fi
+
+cd ot-br-posix
+./script/bootstrap || die "Bootstrapping ot-br-posix"
+./script/setup || die "ot-br-posix setup"
+
+# configure our ncpapp as the socket
+WPANTUND_CONF="/etc/wpantund.conf"
+if grep -Eq '^Config:NCP:SocketPath.*'
+then
+	sudo sed -i '/^Config:NCP:SocketPath/d' "$WPANTUND_CONF"
+fi
+echo "Config:NCP:SocketPath \"system:${NCPAPP_PATH} 1\"" | sudo tee -a $WPANTUND_CONF > /dev/null || die "configuring ncpapp"
+
+echo "Wifi Access point set up with credentials:"
+sudo nmcli -s c show BorderRouter-AP | grep -E '(wireless\.ssid:|security\.psk:)'
+
+echo "Border Router setup complete. Please reboot the pi with 'sudo reboot' and see https://openthread.io/guides/border-router/web-gui for more info."

--- a/RaspiBRSetup.sh
+++ b/RaspiBRSetup.sh
@@ -65,7 +65,7 @@ cd ot-br-posix
 
 # configure our ncpapp as the socket
 WPANTUND_CONF="/etc/wpantund.conf"
-if grep -Eq '^Config:NCP:SocketPath.*'
+if grep -Eq '^Config:NCP:SocketPath.*' ${WPANTUND_CONF}
 then
 	sudo sed -i '/^Config:NCP:SocketPath/d' "$WPANTUND_CONF"
 fi

--- a/RaspiFullInstall.sh
+++ b/RaspiFullInstall.sh
@@ -98,6 +98,9 @@ cmake ../cascoda-sdk || die "Failed to configure"
 # Build
 make -j4 || die "Failed to build"
 
+# Run unit tests
+make test || die "Unit tests failed"
+
 echo "Cascoda binaries built into ./build-${MACHINE_NAME}/bin"
 # Now all of the binaries are installed in ./bin/
 # and can be run for instance ./bin/serial-adapter

--- a/RaspiFullInstall.sh
+++ b/RaspiFullInstall.sh
@@ -61,7 +61,7 @@ if [ "$CMAKE_VER" == apt ]
 then
 	# Install cmake from apt
 	echo "Installing CMake from apt"
-	sudo apt install cmake || die "installing cmake from apt"
+	sudo apt install cmake -y || die "installing cmake from apt"
 	# Install ccmake (we allow this to fail)
 	sudo apt install cmake-curses-gui
 	CMAKE_VER="done"
@@ -82,7 +82,7 @@ sudo udevadm control --reload-rules && sudo udevadm trigger
 # Pull if already exists, otherwise clone.
 if [ -d cascoda-sdk/.git ]
 then
-	git pull -C cascoda-sdk || die "Failed to pull"
+	git -C cascoda-sdk pull || die "Failed to pull"
 else
 	git clone https://github.com/Cascoda/cascoda-sdk.git cascoda-sdk || die "Failed to clone"
 fi

--- a/RaspiFullInstall.sh
+++ b/RaspiFullInstall.sh
@@ -5,8 +5,6 @@
 # Function to die with error
 die() { echo "Error: " "$*" 1>&2 ; exit 1; }
 
-sudo() { echo "Sudo: " "$*" 1>&2 ; }
-
 # Use apt to update and get required packages
 sudo apt update -y || die "sudo apt update"
 sudo apt upgrade -y || die "sudo apt upgrade"
@@ -95,10 +93,10 @@ mkdir build-${MACHINE_NAME}
 cd build-${MACHINE_NAME}
 
 # Configure with cmake
-cmake ../cascoda-sdk
+cmake ../cascoda-sdk || die "Failed to configure"
 
 # Build
-make -j4
+make -j4 || die "Failed to build"
 
 echo "Cascoda binaries built into ./build-${MACHINE_NAME}/bin"
 # Now all of the binaries are installed in ./bin/

--- a/RaspiFullInstall.sh
+++ b/RaspiFullInstall.sh
@@ -2,35 +2,104 @@
 
 # A Script to setup the cascoda-sdk on a fresh Raspberry Pi
 
+# Function to die with error
+die() { echo "Error: " "$*" 1>&2 ; exit 1; }
+
+sudo() { echo "Sudo: " "$*" 1>&2 ; }
+
 # Use apt to update and get required packages
-sudo apt update -y
-sudo apt upgrade -y
-sudo apt install automake gcc g++ git vim libtool lsb-release make libhidapi-dev libncurses5-dev -y
+sudo apt update -y || die "sudo apt update"
+sudo apt upgrade -y || die "sudo apt upgrade"
+sudo apt install automake gcc g++ git vim libtool lsb-release make libhidapi-dev libncurses5-dev -y || die "sudo apt install"
 
-# Download latest cmake source, build, install
-CMAKE_TARGET_VER=cmake-3.14.2
-wget https://github.com/Kitware/CMake/releases/download/v3.14.2/${CMAKE_TARGET_VER}.tar.gz
-tar -xf ${CMAKE_TARGET_VER}.tar.gz
-cd ${CMAKE_TARGET_VER}
-./bootstrap
-make -j4
-sudo make install
-cd ../
+# Check if cmake is already installed
+CMAKE_VER=$(cmake --version 2> /dev/null | awk '
+	/cmake version/{
+		n=split($3,version,".");
+		if(version[1] > 3 || (version[1] == 3 && version[2] >= 13))
+		{
+			print "done"
+		}
+		else
+		{
+			print "install"
+		}
+	}')
 
-#Add chili usb to the udev rules (So chili dongle can be used without sudo)
-echo "SUBSYSTEMS==\"usb\", ATTRS{idVendor}==\"0416\", ATTRS{idProduct}==\"5020\", ACTION==\"add\", MODE=\"0666\"" > tmpfile
-sudo mv tmpfile /etc/udev/rules.d/99-cascoda.rules
-sudo udevadm control --reload-rules && udevadm trigger
+# If not installed, check how best to install it
+if [ "$CMAKE_VER" == install ] || [ -z "$CMAKE_VER" ]
+then
+	# Check if the apt version of cmake is sufficient
+	CMAKE_VER=$(apt-cache policy cmake | awk '
+	/Candidate/{
+		n=split($2,version,".");
+		if(version[1] > 3 || (version[1] == 3 && version[2] >= 13))
+		{
+			print "apt"
+		}
+		else 
+		{
+			print "source"
+		}
+	}')
+fi
+
+if [ "$CMAKE_VER" == source ]
+then
+	# Download latest cmake source, build, install
+	echo "Installing CMake from source"
+	CMAKE_TARGET_VER=cmake-3.14.2
+	wget https://github.com/Kitware/CMake/releases/download/v3.14.2/${CMAKE_TARGET_VER}.tar.gz || die "downloading cmake"
+	tar -xf ${CMAKE_TARGET_VER}.tar.gz || die "extracting cmake"
+	cd ${CMAKE_TARGET_VER}
+	./bootstrap || die "bootstrap cmake"
+	make -j4 || die "making cmake"
+	sudo make install || die "installing cmake"
+	cd ../
+	CMAKE_VER="done"
+fi
+
+if [ "$CMAKE_VER" == apt ]
+then
+	# Install cmake from apt
+	echo "Installing CMake from apt"
+	sudo apt install cmake || die "installing cmake from apt"
+	# Install ccmake (we allow this to fail)
+	sudo apt install cmake-curses-gui
+	CMAKE_VER="done"
+fi
+
+if [ "$CMAKE_VER" != done ]
+then
+	die "CMake could not be installed!"
+else
+	echo "CMake installed!"
+fi
+
+# Add chili usb to the udev rules (So chili dongle can be used without sudo)
+echo 'SUBSYSTEMS=="usb", ATTRS{idVendor}=="0416", ATTRS{idProduct}=="5020", ACTION=="add", MODE="0666"' | sudo tee /etc/udev/rules.d/99-cascoda.rules > /dev/null
+sudo udevadm control --reload-rules && sudo udevadm trigger
 
 # Clone the Cascoda sdk, set up build dir, configure
-git clone https://github.com/Cascoda/cascoda-sdk.git
+# Pull if already exists, otherwise clone.
+if [ -d cascoda-sdk/.git ]
+then
+	git pull -C cascoda-sdk || die "Failed to pull"
+else
+	git clone https://github.com/Cascoda/cascoda-sdk.git cascoda-sdk || die "Failed to clone"
+fi
+
+# Make a build directory and cd in
 MACHINE_NAME="$(uname -m)"
 mkdir build-${MACHINE_NAME}
 cd build-${MACHINE_NAME}
+
+# Configure with cmake
 cmake ../cascoda-sdk
 
 # Build
 make -j4
 
+echo "Cascoda binaries built into ./build-${MACHINE_NAME}/bin"
 # Now all of the binaries are installed in ./bin/
 # and can be run for instance ./bin/serial-adapter


### PR DESCRIPTION
This allows the scripts to be a bit more useful and efficient.

Change list:

1. Added Github Actions CI to check functionality.
2. Use existing installed cmake if possible
3. Download cmake from apt if not
4. Use compiling from source as last resort if 2 or 3 aren't possible
5. Allow RaspiFullInstall script to be used for updating as well as first install
6. Provide sensible error messages & teminate if something fails
7. Add RaspiBRSetup.sh to set up a fresh pi as a border router using Cascoda dongle/hat. (this is still in early days)