### PR TITLE
Add script to reload the border agent when thread interface comes up

### DIFF
--- a/_BRSetup.sh
+++ b/_BRSetup.sh
@@ -155,6 +155,11 @@ sudo cp "${MYDIR}/conf/prefix_add" /etc/ncp_state_notifier/dispatcher.d/prefix_a
 sudo sed -i -e "${SED_ULA_SUB}" /etc/ncp_state_notifier/dispatcher.d/prefix_add || die "prefix_add sub"
 sudo chmod a+x /etc/ncp_state_notifier/dispatcher.d/prefix_add || die "prefix_add chmod"
 
+# Configure ot border agent reloader
+sudo mv /etc/ncp_state_notifier/dispatcher.d/agent_reloader /etc/ncp_state_notifier/dispatcher.d/agent_reloader.bak
+sudo cp "${MYDIR}/conf/agent_reloader" /etc/ncp_state_notifier/dispatcher.d/agent_reloader || die "agent_reloader conf"
+sudo chmod a+x /etc/ncp_state_notifier/dispatcher.d/agent_reloader || die "agent_reloader chmod"
+
 # Disable raspberry pi console on UART, enable uart, add required environment variable to use pi hat
 sudo sed -i 's/console=serial0,115200 //g' /boot/cmdline.txt
 echo "enable_uart=1" | sudo tee -a /boot/config.txt

--- a/conf/agent_reloader
+++ b/conf/agent_reloader
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Restart the border agent after first associated to (quick) fix what looks like a race
+# with avahi daemon.
+
+STATE=$1
+
+if [ ${STATE} = "associated" ]; then
+    sudo systemctl restart otbr-agent.service
+fi

--- a/conf/prefix_add
+++ b/conf/prefix_add
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# This script adds the off-mesh prefix to the Thread network, and sets up the
+# relevant rules and daemons on the posix side to enable multicast forwarding.
+
 STATE=$1
 
 if [ ${STATE} = "associated" ]; then


### PR DESCRIPTION
This is a workaround for an issue that was preventing the commissioning app from finding the border router
if it was started up with both ethernet and wifi on recent versions of raspbian.